### PR TITLE
fix: strings are unicode

### DIFF
--- a/wtf_polyglot/meta.py
+++ b/wtf_polyglot/meta.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 try:
     from html import escape
     from html.parser import HTMLParser


### PR DESCRIPTION
Prevent errors like:
UnicodeEncodeError: 'ascii' codec can't encode character u'\xeb'...
